### PR TITLE
Can set failure image which will be displayed in error case

### DIFF
--- a/Classes/IDMPhotoBrowser.h
+++ b/Classes/IDMPhotoBrowser.h
@@ -43,6 +43,7 @@
 @property (nonatomic, weak) UIImage *leftArrowImage, *leftArrowSelectedImage;
 @property (nonatomic, weak) UIImage *rightArrowImage, *rightArrowSelectedImage;
 @property (nonatomic, weak) UIImage *actionButtonImage, *actionButtonSelectedImage;
+@property (nonatomic, strong) UIImage *failureImage;
 
 // View customization
 @property (nonatomic) BOOL displayDoneButton;

--- a/Classes/IDMPhotoBrowser.m
+++ b/Classes/IDMPhotoBrowser.m
@@ -135,6 +135,7 @@ NSLocalizedStringFromTableInBundle((key), nil, [NSBundle bundleWithPath:[[NSBund
 // Properties
 @synthesize displayDoneButton = _displayDoneButton, displayToolbar = _displayToolbar, displayActionButton = _displayActionButton, displayCounterLabel = _displayCounterLabel, useWhiteBackgroundColor = _useWhiteBackgroundColor, doneButtonImage = _doneButtonImage;
 @synthesize leftArrowImage = _leftArrowImage, rightArrowImage = _rightArrowImage, leftArrowSelectedImage = _leftArrowSelectedImage, rightArrowSelectedImage = _rightArrowSelectedImage, actionButtonImage = _actionButtonImage, actionButtonSelectedImage = _actionButtonSelectedImage;
+@synthesize failureImage = _failureImage;
 @synthesize displayArrowButton = _displayArrowButton, actionButtonTitles = _actionButtonTitles;
 @synthesize arrowButtonsChangePhotosAnimated = _arrowButtonsChangePhotosAnimated;
 @synthesize forceHideStatusBar = _forceHideStatusBar;
@@ -997,6 +998,7 @@ NSLocalizedStringFromTableInBundle((key), nil, [NSBundle bundleWithPath:[[NSBund
             page = [[IDMZoomingScrollView alloc] initWithPhotoBrowser:self];
             page.backgroundColor = [UIColor clearColor];
             page.opaque = YES;
+            page.failureImage = self.failureImage;
 
 			[self configurePage:page forIndex:index];
 			[_visiblePages addObject:page];

--- a/Classes/IDMZoomingScrollView.h
+++ b/Classes/IDMZoomingScrollView.h
@@ -26,9 +26,13 @@
 	IDMTapDetectingView *_tapView; // for background taps
     
     DACircularProgressView *_progressView;
+    UIImageView *_failureView;
+    UIImage *_failureImage;
 }
 
 @property (nonatomic, strong) IDMTapDetectingImageView *photoImageView;
+@property (nonatomic, strong) UIImageView *failureView;
+@property (nonatomic, strong) UIImage *failureImage;
 @property (nonatomic, strong) IDMCaptionView *captionView;
 @property (nonatomic, strong) id<IDMPhoto> photo;
 @property (nonatomic) CGFloat maximumDoubleTapZoomScale;

--- a/Classes/IDMZoomingScrollView.m
+++ b/Classes/IDMZoomingScrollView.m
@@ -29,6 +29,7 @@
 @implementation IDMZoomingScrollView
 
 @synthesize photoImageView = _photoImageView, photoBrowser = _photoBrowser, photo = _photo, captionView = _captionView;
+@synthesize failureView = _failureView, failureImage = _failureImage;
 
 - (id)initWithPhotoBrowser:(IDMPhotoBrowser *)browser {
     if ((self = [super init])) {
@@ -66,6 +67,10 @@
         _progressView.trackTintColor    = browser.trackTintColor    ? self.photoBrowser.trackTintColor    : [UIColor colorWithWhite:0.2 alpha:1];
         _progressView.progressTintColor = browser.progressTintColor ? self.photoBrowser.progressTintColor : [UIColor colorWithWhite:1.0 alpha:1];
         [self addSubview:_progressView];
+
+        _failureView = [[UIImageView alloc] init];
+        _failureView.contentMode = UIViewContentModeCenter;
+        [self addSubview:_failureView];
         
 		// Setup
 		self.backgroundColor = [UIColor clearColor];
@@ -105,6 +110,8 @@
         
 		self.contentSize = CGSizeMake(0, 0);
 		
+		_failureView.hidden = YES;
+
 		// Get image from browser as it handles ordering of fetching
 		UIImage *img = [self.photoBrowser imageForPhoto:_photo];
 		if (img) {
@@ -149,6 +156,9 @@
 
 // Image failed so just show black!
 - (void)displayImageFailure {
+    _failureView.hidden = NO;
+    _failureView.frame = self.bounds;
+    _failureView.image = self.failureImage;
     [_progressView removeFromSuperview];
 }
 


### PR DESCRIPTION
Currently the way i found to show error image is to implement method of `IDMPhotoBrowserDelegate`:
```
- (void)photoBrowser:(IDMPhotoBrowser *)photoBrowser imageFailed:(NSUInteger)index imageView:(IDMTapDetectingImageView *)imageView {
    imageView.image = [UIImage imageNamed:@"photoError"];
    imageView.hidden = NO;
    imageView.frame = self.view.bounds;
    imageView.contentMode = UIViewContentModeCenter;
}
```

And this way has side effect: the image flies away on double tap.

Here I offer not so flexible but clear and straghitforward way: new property of `IDMPhotoBrowser` named `failureImage`.
